### PR TITLE
Fix docs concurrency deadlock

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,8 +12,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   docs:


### PR DESCRIPTION
This changes the workflow concurrency group to avoid deadlock with the reusable pages deployment workflow.