### PR TITLE
feat: improve SEO, GEO, and agentic discoverability of docs site

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,29 @@
+User-agent: *
+Allow: /
+
+# Explicitly allow AI crawlers for GEO and agentic access
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+Sitemap: https://www.indrapatil.com/crosszip/sitemap.xml

--- a/hooks.py
+++ b/hooks.py
@@ -1,0 +1,14 @@
+import os
+
+
+def on_post_build(config, **kwargs):
+    well_known = os.path.join(config["site_dir"], ".well-known")
+    os.makedirs(well_known, exist_ok=True)
+    with open(os.path.join(well_known, "llms.txt"), "w") as f:
+        f.write(
+            "# LLM Documentation Index for crosszip\n"
+            "# Machine-readable documentation index for AI assistants\n"
+            "# See https://llmstxt.org/ for the specification\n\n"
+            "/llms.txt: Concise package overview for AI assistants\n"
+            "/llms-full.txt: Complete package documentation for AI assistants\n"
+        )

--- a/hooks.py
+++ b/hooks.py
@@ -1,14 +1,15 @@
-import os
+from pathlib import Path
+from typing import Any
 
 
-def on_post_build(config, **kwargs):
-    well_known = os.path.join(config["site_dir"], ".well-known")
-    os.makedirs(well_known, exist_ok=True)
-    with open(os.path.join(well_known, "llms.txt"), "w") as f:
-        f.write(
-            "# LLM Documentation Index for crosszip\n"
-            "# Machine-readable documentation index for AI assistants\n"
-            "# See https://llmstxt.org/ for the specification\n\n"
-            "/llms.txt: Concise package overview for AI assistants\n"
-            "/llms-full.txt: Complete package documentation for AI assistants\n"
-        )
+def on_post_build(config: dict[str, Any]) -> None:
+    well_known = Path(config["site_dir"]) / ".well-known"
+    well_known.mkdir(exist_ok=True)
+    (well_known / "llms.txt").write_text(
+        "# LLM Documentation Index for crosszip\n"
+        "# Machine-readable documentation index for AI assistants\n"
+        "# See https://llmstxt.org/ for the specification\n\n"
+        "/llms.txt: Concise package overview for AI assistants\n"
+        "/llms-full.txt: Complete package documentation for AI assistants\n",
+        encoding="utf-8",
+    )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
 
 theme:
   name: material
+  custom_dir: overrides
   logo: assets/logo.png
   favicon: assets/favicon.ico
   features:
@@ -114,6 +115,14 @@ extra_javascript:
 
 extra_css:
   - stylesheets/pyodide_runner.css
+
+extra:
+  analytics:
+    provider: google
+    property: G-3BQ49J7KYH
+
+hooks:
+  - hooks.py
 
 validation:
   omitted_files: warn

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareSourceCode",
+    "name": "crosszip",
+    "description": "A Python library for iterating over all combinations from multiple iterables. Provides a simple and efficient way to apply functions across combinations of elements.",
+    "url": "https://www.indrapatil.com/crosszip/",
+    "codeRepository": "https://github.com/IndrajeetPatil/crosszip",
+    "programmingLanguage": {
+      "@type": "ComputerLanguage",
+      "name": "Python"
+    },
+    "license": "https://opensource.org/licenses/MIT",
+    "version": "1.4.0",
+    "author": {
+      "@type": "Person",
+      "name": "Indrajeet Patil",
+      "url": "https://www.indrapatil.com/",
+      "sameAs": "https://orcid.org/0000-0003-1995-6531"
+    },
+    "keywords": ["Python", "itertools", "combinations", "cartesian product", "pytest", "parametrize", "testing"]
+  }
+  </script>
+  <meta name="citation_title" content="crosszip: Iterating over all combinations from multiple iterables" />
+  <meta name="citation_author" content="Indrajeet Patil" />
+  <meta name="citation_software_version" content="1.4.0" />
+  <link rel="alternate" type="text/plain" href="/crosszip/llms.txt" title="LLM-friendly documentation summary" />
+  <link rel="alternate" type="text/plain" href="/crosszip/llms-full.txt" title="Full LLM documentation" />
+{% endblock %}


### PR DESCRIPTION
## Summary

- **Google Analytics**: Added GA4 (G-3BQ49J7KYH) using zensical's native `extra.analytics` config in `mkdocs.yml` — no custom JavaScript needed
- **Schema.org JSON-LD**: Added `SoftwareSourceCode` structured data via `overrides/main.html` (Material for MkDocs `extrahead` block) — injected into `<head>` on every page so search engines and AI systems understand the project
- **Academic citation meta tags**: `citation_title`, `citation_author`, `citation_software_version` in the same template override
- **LLM link relations**: `<link rel="alternate">` pointing to the `llmstxt`-plugin-generated `llms.txt` and `llms-full.txt` — signals their existence to crawlers
- **`docs/robots.txt`**: Explicitly allows all major AI crawlers (GPTBot, ClaudeBot, OAI-SearchBot, PerplexityBot, Google-Extended, anthropic-ai). MkDocs auto-copies non-md files from `docs/` to `site/`, so no workflow changes needed.
- **`hooks.py`**: MkDocs hook that writes `.well-known/llms.txt` to `site/` after build. MkDocs skips hidden directories (those starting with `.`), so a hook is the right mechanism. Runs during `zensical build`, before the Pages artifact is uploaded.

## What was already in place (no changes needed)

- `llms.txt` and `llms-full.txt` — generated by the `llmstxt` plugin
- `sitemap.xml` — generated by zensical/MkDocs
- No separate GHA workflow needed — all changes integrate directly into the existing build step

## Test plan

- [ ] Merge and wait for Docs workflow to complete
- [ ] Check `https://www.indrapatil.com/crosszip/robots.txt` returns the robots file
- [ ] Check `https://www.indrapatil.com/crosszip/.well-known/llms.txt` returns the index
- [ ] View page source and confirm GA script and JSON-LD appear in `<head>`
- [ ] Validate JSON-LD via Google's Rich Results Test
- [ ] Confirm GA events appear in Google Analytics dashboard