### PR TITLE
ci: add reusable prek workflow

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,11 @@
+on:
+  pull_request:
+    branches: [main]
+
+name: prek
+
+jobs:
+  prek:
+    uses: IndrajeetPatil/workflows/.github/workflows/pre-commit.yaml@main
+    permissions:
+      contents: write

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -6,6 +6,6 @@ name: prek
 
 jobs:
   prek:
-    uses: IndrajeetPatil/workflows/.github/workflows/pre-commit.yaml@main
+    uses: IndrajeetPatil/workflows/.github/workflows/pre-commit.yaml@c73d24befb19ed51e2737558d076189ac23ad69d
     permissions:
-      contents: write
+      contents: read


### PR DESCRIPTION
## Summary
- add a `pre-commit.yaml` workflow for pull requests to `main`
- use the reusable `IndrajeetPatil/workflows/.github/workflows/pre-commit.yaml@main` workflow
- grant `contents: write` to match the existing reusable workflow usage pattern
