### PR TITLE
docs: add AGENTS.md and copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,33 @@
+# Copilot Instructions
+
+*(This file is based on AGENTS.md)*
+
+This is a Python package repository following standard development practices.
+
+## Project Structure
+- `src/`: Contains the main package code.
+- `tests/`: Contains the `pytest` test suite.
+- `docs/`: Contains documentation files.
+- `pyproject.toml`: The primary configuration file for metadata and tools.
+- `uv.lock`: Lockfile ensuring reproducible environments.
+
+## Setup & Dependencies
+- We use [`uv`](https://github.com/astral-sh/uv) for fast package and environment management.
+- **Do not** use `pip`, `pipenv`, or `poetry` directly.
+- **Do not** manually edit `uv.lock`.
+- To reproduce the locked environment, run `uv sync`.
+- To explicitly upgrade dependencies and pre-commit hooks, run `make update-deps`.
+
+## Code Quality & Testing
+- Code formatting and linting are handled by `ruff`, and type checking by `ty`.
+- Pre-commit hooks are configured via `prek`.
+- **Do not** commit code with linting errors, type warnings, or failing tests.
+- Always run `make qa` to format, lint, and type-check your code.
+- Run `make check-package` to run the full validation suite (QA + Tests + Build).
+- **Do not** bypass the `Makefile`; rely on its targets for standardized workflows.
+
+## Contribution Workflow
+1. Ensure you are on a feature branch.
+2. Implement your code changes within `src/` and corresponding tests within `tests/`.
+3. Verify all changes by running `make check-package`.
+4. Commit your changes and push to the branch to update the Pull Request.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,9 @@ This is a Python package repository following standard development practices.
 ## Setup & Dependencies
 - We use [`uv`](https://github.com/astral-sh/uv) for fast package and environment management.
 - **Do not** use `pip`, `pipenv`, or `poetry` directly.
-- **Do not** manually edit `uv.lock`. Use `make update-deps` to sync and update dependencies.
+- **Do not** manually edit `uv.lock`. 
+- To reproduce the locked environment, run `uv sync`.
+- To explicitly upgrade dependencies and pre-commit hooks, run `make update-deps`.
 
 ## Code Quality & Testing
 - Code formatting and linting are handled by `ruff`, and type checking by `ty`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# Agent Instructions
+
+This is a Python package repository following standard development practices.
+
+## Project Structure
+- `src/`: Contains the main package code.
+- `tests/`: Contains the `pytest` test suite.
+- `docs/`: Contains documentation files.
+- `pyproject.toml`: The primary configuration file for metadata and tools.
+- `uv.lock`: Lockfile ensuring reproducible environments.
+
+## Setup & Dependencies
+- We use [`uv`](https://github.com/astral-sh/uv) for fast package and environment management.
+- **Do not** use `pip`, `pipenv`, or `poetry` directly.
+- **Do not** manually edit `uv.lock`. Use `make update-deps` to sync and update dependencies.
+
+## Code Quality & Testing
+- Code formatting and linting are handled by `ruff`, and type checking by `ty`.
+- Pre-commit hooks are configured via `prek`.
+- **Do not** commit code with linting errors, type warnings, or failing tests.
+- Always run `make qa` to format, lint, and type-check your code.
+- Run `make check-package` to run the full validation suite (QA + Tests + Build).
+- **Do not** bypass the `Makefile`; rely on its targets for standardized workflows.
+
+## Contribution Workflow
+1. Ensure you are on a feature branch.
+2. Implement your code changes within `src/` and corresponding tests within `tests/`.
+3. Verify all changes by running `make check-package`.
+4. Commit your changes and push to the branch to update the Pull Request.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This is a Python package repository following standard development practices.
 ## Setup & Dependencies
 - We use [`uv`](https://github.com/astral-sh/uv) for fast package and environment management.
 - **Do not** use `pip`, `pipenv`, or `poetry` directly.
-- **Do not** manually edit `uv.lock`. 
+- **Do not** manually edit `uv.lock`.
 - To reproduce the locked environment, run `uv sync`.
 - To explicitly upgrade dependencies and pre-commit hooks, run `make update-deps`.
 


### PR DESCRIPTION
Adds a succinct `AGENTS.md` file and `.github/copilot-instructions.md` to help coding agents (and GitHub Copilot) navigate and work within this repository more efficiently.